### PR TITLE
Run alpr with Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,45 @@
+FROM tensorflow/tensorflow:1.5.0-gpu
+USER root
+
+ARG NAME=alpr
+
+WORKDIR /home/${NAME}
+
+# Install project related software
+RUN apt-get update && \
+    apt-get install -y \
+    wget \
+    cmake \
+    libavcodec-dev \
+    libavformat-dev \
+    libswscale-dev \
+    libtbb2 \
+    libtbb-dev \
+    libjpeg-dev \
+    libpng-dev \
+    libtiff-dev \
+    libjasper-dev \
+    libdc1394-22-dev
+
+# Install project related python packages
+RUN pip install --upgrade pip && \
+    pip install keras==2.2.4
+
+# install opencv
+RUN wget https://sourceforge.net/projects/opencvlibrary/files/opencv-unix/2.4.13/opencv-2.4.13.zip && \
+    unzip opencv-2.4.13.zip && \
+    cd opencv-2.4.13/ && \
+    mkdir build && \
+    cd build && \
+    cmake -D CMAKE_BUILD_TYPE=RELEASE -D CMAKE_INSTALL_PREFIX=/usr/local -D BUILD_PYTHON_SUPPORT=ON -D WITH_XINE=ON -D WITH_TBB=ON .. && \
+    make -j$(nproc) && make install -j$(nproc) && \
+    cd ../.. && \
+    rm opencv-2.4.13.zip
+
+COPY . .
+
+RUN cd /home/${NAME}/darknet && \
+    make && \
+    cd ..
+
+RUN bash get-networks.sh

--- a/README.md
+++ b/README.md
@@ -19,7 +19,34 @@ If you use results produced by our code in any publication, please cite our pape
   month={Sep},}
 ```
 
-## Requirements
+## Install with Docker
+
+Using Docker helps you to create an environment tailor-fit for the project without needing to change anything on your computer.
+### Requirements
+Install [Docker](https://www.docker.com/get-started) and [docker-compose](https://docs.docker.com/compose/install/) on your machine.  
+Prepare Docker for running on GPU: edit `/etc/docker/daemon.json` by adding the first level key `"default-runtime": "nvidia"`.
+Restart docker daemon (`sudo service docker restart`)
+
+### Install
+```bash
+cd alpr-unconstrained
+
+# build docker environment
+docker-compose build
+
+# run & enter docker container
+docker-compose run --rm alpr
+
+# exit
+ctrl+D
+```
+Then inside the container follow the same procedure as in the section _Running a simple script_.
+> You will have root privileges inside the container so proceed with caution.  
+Currently the docker-compose.yaml synchronizes only the `samples` folder of your local computer with the container `samples` folder. If you wish to have other folders from your local computer synchronized with the container, you need to edit [volumes](https://docs.docker.com/storage/volumes/) in the docker-compose.yaml.
+
+## Without Docker
+
+### Requirements
 
 In order to easily run the code, you must have installed the Keras framework with TensorFlow backend. The Darknet framework is self-contained in the "darknet" folder and must be compiled before running the tests. To build Darknet just type "make" in "darknet" folder:
 
@@ -29,7 +56,7 @@ $ cd darknet && make
 
 **The current version was tested in an Ubuntu 16.04 machine, with Keras 2.2.4, TensorFlow 1.5.0, OpenCV 2.4.9, NumPy 1.14 and Python 2.7.**
 
-## Download Models
+### Download Models
 
 After building the Darknet framework, you must execute the "get-networks.sh" script. This will download all the trained models:
 
@@ -45,7 +72,7 @@ Use the script "run.sh" to run our ALPR approach. It requires 3 arguments:
 * __CSV file (-c):__ specify an output CSV file.
 
 ```shellscript
-$ bash get-networks.sh && bash run.sh -i samples/test -o /tmp/output -c /tmp/output/results.csv
+$ bash run.sh -i samples/test -o /tmp/output -c /tmp/output/results.csv
 ```
 
 ## Training the LP detector

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,13 @@
+version: "2.3"
+
+services:
+  alpr:
+    build: .
+    runtime: nvidia
+    volumes:
+      - ./samples:/home/alpr/samples
+    command: /bin/bash
+    stdin_open: true
+    tty: true
+    environment:
+      - CUDA_VISIBLE_DEVICES=3

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -9,5 +9,3 @@ services:
     command: /bin/bash
     stdin_open: true
     tty: true
-    environment:
-      - CUDA_VISIBLE_DEVICES=3


### PR DESCRIPTION
Allow users to use Docker-compose for running `alpr-unconstrained`.
Changes :

- add `Dockerfile` which creates an environment with python2.7, TF, Keras, opencv installed, darnknet compiled and models downloaded by only running the command: `docker-compose build`.
- add `docker-compose.yaml` file which makes the usage of Docker easier (the options for launching the container, like GPU usage and volumes, are written inside the docker-compose file rather than writing a huge command line for launching the container)
- write indications in the Readme for how to use these tools.